### PR TITLE
Fix for the post-GLR Perl 6

### DIFF
--- a/lib/TAP/Harness.pm6
+++ b/lib/TAP/Harness.pm6
@@ -206,7 +206,7 @@ package TAP::Runner {
 
 		method new(Source :$source, :@handlers, Promise :$bailout) {
 			my $state = State.new(:$bailout);
-			my TAP::Entry::Handler @all_handlers = $state, @handlers;
+			my TAP::Entry::Handler @all_handlers = flat $state, @handlers;
 			my $run = get_runner($source, @all_handlers);
 			return Async.bless(:name($source.name), :$state, :$run);
 		}

--- a/t/string.t
+++ b/t/string.t
@@ -94,7 +94,7 @@ sub parse-and-get($content, :$tests-planned, :$tests-run, :$passed, :$failed, :$
 	is($result.todo-passed.elems, $todo-passed, "Expected $todo-passed todo-passed tests in $name") if $todo-passed.defined;
 	is($result.skipped.elems, $skipped, "Expected $skipped skipped tests in $name") if $skipped.defined;
 	is($result.unknowns, $unknowns, "Expected $unknowns unknown tests in $name") if $unknowns.defined;
-	is-deeply($result.errors, Array[Str].new(@errors), 'Got expected errors: ' ~ @errors.map({qq{"$_"}}).join(', ')) if @errors.defined;
+	is-deeply($result.errors, Array[Str].new(|@errors), 'Got expected errors: ' ~ @errors.map({qq{"$_"}}).join(', ')) if @errors.defined;
 
 	diag("Finished $name");
 	return $result;


### PR DESCRIPTION
Things need explicit flattening sometimes. This also works on pre-GLR rakudo