### PR TITLE
Removed Type:D from uninitialized member variables.

### DIFF
--- a/lib/TAP/Entry.pm6
+++ b/lib/TAP/Entry.pm6
@@ -7,7 +7,7 @@ package TAP {
 		}
 	}
 	class Version does Entry {
-		has Int:D $.version;
+		has Int $.version;
 		method to-string() {
 			return "TAP Version $!version";
 		}
@@ -25,7 +25,7 @@ package TAP {
 	subset Directive::Explanation of Str where { not .defined or m/ ^ \N* $ / };
 
 	class Test does Entry {
-		has Bool:D $.ok;
+		has Bool $.ok;
 		has Int $.number;
 		has Str $.description;
 		has Directive:D $.directive = No-Directive;
@@ -75,13 +75,13 @@ package TAP {
 		}
 	}
 	class Comment does Entry {
-		has Str:D $.comment;
+		has Str $.comment;
 		method to-string {
 			return "# $!comment";
 		}
 	}
 	class YAML does Entry {
-		has Str:D $.serialized;
+		has Str $.serialized;
 		has Any $.deserialized;
 		method to-string {
 			return "  ---\n" ~ $!serialized.indent(2) ~~ '  ...'

--- a/lib/TAP/Harness.pm6
+++ b/lib/TAP/Harness.pm6
@@ -120,7 +120,7 @@ package TAP::Runner {
 	my class Run {
 		subset Killable of Any where *.can('kill');
 		has Killable $!process;
-		has Promise:D $.done;
+		has Promise $.done;
 		has Promise $.timer;
 		method kill() {
 			$!process.kill if $!process;
@@ -281,7 +281,7 @@ class TAP::Harness {
 
 	has SourceHandler @.handlers = SourceHandler::Perl6.new();
 	has Any @.sources;
-	has TAP::Reporter:T $.reporter-class = TAP::Reporter::Console;
+	has TAP::Reporter $.reporter-class = TAP::Reporter::Console;
 
 	class Run {
 		has Promise $.done handles <result>;

--- a/lib/Test/Event.pm6
+++ b/lib/Test/Event.pm6
@@ -5,7 +5,7 @@ package Test {
 	}
 
 	class Event::Plan does Event {
-		has Int:D $.tests;
+		has Int $.tests;
 		has Bool $.skip-all;
 		has Str $.explanation;
 	}
@@ -18,7 +18,7 @@ package Test {
 	}
 
 	class Event::Comment does Event {
-		has Str:D $.content;
+		has Str $.content;
 	}
 
 }

--- a/lib/Test/Stream.pm6
+++ b/lib/Test/Stream.pm6
@@ -34,7 +34,7 @@ package Test {
 	}
 
 	my class Context::Main does Context {
-		has TAP::Entry::Handler:D $.output;
+		has TAP::Entry::Handler $.output;
 		method emit(TAP::Entry $entry) {
 			$!output.handle-entry($entry);
 		}
@@ -60,7 +60,7 @@ package Test {
 		}
 	}
 	class Stream {
-		has TAP::Entry::Handler:D $.output;
+		has TAP::Entry::Handler $.output;
 		has Int $.version;
 		has Context @!constack;
 		has Context $!context handles <tests-seen handle-entry>;


### PR DESCRIPTION
By changing the following, it is currently invalid specified in the order.

https://github.com/rakudo/rakudo/commit/7f0e6a5